### PR TITLE
Patch for the issue I reported today

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -37,7 +37,7 @@ module Mogli
       parts = post_data.split("&")
       hash = {}
       parts.each do |p| (k,v) = p.split("=")
-        hash[k]=v
+        hash[k]=CGI.unescape(v)
       end
       new(hash["access_token"],hash["expires"].to_s.to_i)
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -53,15 +53,15 @@ describe Mogli::Client do
       client.default_params.should == {}
     end
 
-    it "create get access token from an authenticator and code" do
-      Mogli::Client.should_receive(:get).with("url").and_return("access_token=114355055262088|2.6_s8VD_HRneAq3_tUEHJhA__.3600.1272920400-12451752|udZzWly7ptI7IMgX7KTdzaoDrhU.&expires=4168")
+    it "create get an unescaped access token from an authenticator and code" do
+      Mogli::Client.should_receive(:get).with("url").and_return("access_token=114355055262088%7C2.6_s8VD_HRneAq3_tUEHJhA__.3600.1272920400-12451752|udZzWly7ptI7IMgX7KTdzaoDrhU.&expires=4168")
       client = Mogli::Client.create_from_code_and_authenticator("code",mock("auth",:access_token_url=>"url"))
       client.access_token.should == "114355055262088|2.6_s8VD_HRneAq3_tUEHJhA__.3600.1272920400-12451752|udZzWly7ptI7IMgX7KTdzaoDrhU."
       client.expiration.should_not be_nil
     end
 
     it "create set the expiration into the future if there is on param" do
-      Mogli::Client.should_receive(:get).with("url").and_return("access_token=114355055262088|2.6_s8VD_HRneAq3_tUEHJhA__.3600.1272920400-12451752|udZzWly7ptI7IMgX7KTdzaoDrhU.")
+      Mogli::Client.should_receive(:get).with("url").and_return("access_token=114355055262088%7C2.6_s8VD_HRneAq3_tUEHJhA__.3600.1272920400-12451752|udZzWly7ptI7IMgX7KTdzaoDrhU.")
       client = Mogli::Client.create_from_code_and_authenticator("code",mock("auth",:access_token_url=>"url"))
       (client.expiration > Time.now+365*24*60*60).should be_true
     end


### PR DESCRIPTION
Issue is described here:

http://github.com/mmangino/mogli/issues#issue/7

Fixed up the test case in client_spec to pass in an escaped access_token and then fixed client.rb to unescape it.

I don't have a system running this gem as I only started tinkering with it today to see if I want to start using it in production so I haven't given this code a real world test. 

Good work on the gem in general though, it seems pretty much what I need and a fair whack more flexible than facebooker
