### PR TITLE
Added :version, :administrator to Group

### DIFF
--- a/lib/mogli/group.rb
+++ b/lib/mogli/group.rb
@@ -1,7 +1,7 @@
 module Mogli
   class Group < Model
     set_search_type
-    define_properties :id, :name, :description, :link, :privacy, :updated_time
+    define_properties :id, :name, :description, :link, :privacy, :updated_time, :version, :administrator
 
     hash_populating_accessor :owner, "User", "Page"
     hash_populating_accessor :venue, "Address"


### PR DESCRIPTION
These properties are not documented on the Group page, but are returned when querying a user's groups via "/[user id]/groups".
