### PR TITLE
Added ability to include associated models when posting a model to facebook (e.g. Actions for Posts)

### DIFF
--- a/lib/mogli/action.rb
+++ b/lib/mogli/action.rb
@@ -1,6 +1,12 @@
 module Mogli
   class Action < Model
     define_properties :name, :link
-    
+
+    # simple implementation of to_json, ignoring options like :only, :except,
+    # :include, :methods because this is primarily intended for being submitted
+    # to facebook
+    def to_json(options = nil)
+      "{\"name\":\"#{name}\",\"link\":\"#{link}\"}"
+    end
   end
 end

--- a/lib/mogli/post.rb
+++ b/lib/mogli/post.rb
@@ -1,16 +1,18 @@
+require 'json'
+
 module Mogli
   class Post < Model
-        
-    define_properties :id, :to, :message, :picture, :link, :name, :caption, 
+
+    define_properties :id, :to, :message, :picture, :link, :name, :caption,
       :description, :source, :icon, :attribution, :actions, :likes,
       :created_time, :updated_time, :privacy, :type
-    
-    creation_properties :message, :picture, :link, :name, :description, :caption, :source
-        
+
+    creation_properties :message, :picture, :link, :name, :description, :caption, :source, :actions
+
     hash_populating_accessor :actions, "Action"
     has_association :comments, "Comment"
     hash_populating_accessor :from, "User"
-    
+
     def likes_create
       client.post("#{id}/likes",nil,{})
     end


### PR DESCRIPTION
Okay, took a step back and removed the requirement for any JSON-related gems. It's a bit less generic (implemented a quick to_json method for Action), but at least the post_params code should be generic and just looks for to_json methods on things that are in creation_properties.

Hopefully this is much more portable and acceptable!
