### PR TITLE
Check extended permissions for facebook user

### DIFF
--- a/lib/mogli/user.rb
+++ b/lib/mogli/user.rb
@@ -26,5 +26,32 @@ module Mogli
     has_association :likes, "Page"
     has_association :home, "Post"
     has_association :accounts, "Page"
+
+    # allows querying facebook to see if the user has granted the specified
+    # permissions. the permissions arg should be an array of strings or
+    # symbols matching the facebook permissions exactly:
+    # http://developers.facebook.com/docs/authentication/permissions
+    #
+    # returns a hash from permissions to booleans indicating presence or
+    # absence of permission
+    def check_permissions(permissions)
+      fql = "SELECT #{permissions.map(&:to_s).join(',')} " +
+            "FROM permissions " +
+            "WHERE uid = #{self.id}"
+
+      result = client.fql_query(fql).parsed_response.first
+
+      result.each_pair do |perm, val|
+        result[perm] = (val == 1)
+      end
+    end
+
+    # check if the facebook user has a specific permission
+    # the permission arg should be a string or symbol matching the facebook
+    # permissions exactly:
+    # http://developers.facebook.com/docs/authentication/permissions
+    def has_permission?(permission)
+      check_permissions([permission])[permission]
+    end
   end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -64,7 +64,7 @@ describe Mogli::User do
         permissions_list = $1
 
         Mogli::User::ALL_EXTENDED_PERMISSIONS.each do |perm|
-          query.should match /,?#{perm.to_s},?/
+          permissions_list.should match /,?#{perm.to_s},?/
         end
 
         @dummy_response # stubbed return val

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -40,4 +40,68 @@ describe Mogli::User do
     end
   end
 
+  describe "checking extended permissions" do
+    before :each do
+      # construct a response that will avoid errors: we're just testing query
+      @dummy_response = 'dummy response'
+      @dummy_response.stub!(:parsed_response).and_return [{}]
+
+      # this HTTParty parsed response is taken directly from an actual fql response
+      @valid_response = 'valid response'
+      @valid_response.stub!(:parsed_response).and_return [{"publish_stream"=>1, "create_event"=>0, "rsvp_event"=>0, "sms"=>0, "offline_access"=>1, "publish_checkins"=>0, "user_about_me"=>0, "user_activities"=>0, "user_birthday"=>0, "user_education_history"=>0, "user_events"=>0, "user_groups"=>0, "user_hometown"=>0, "user_interests"=>0, "user_likes"=>0, "user_location"=>0, "user_notes"=>0, "user_online_presence"=>0, "user_photo_video_tags"=>0, "user_photos"=>0, "user_relationships"=>0, "user_relationship_details"=>0, "user_religion_politics"=>0, "user_status"=>0, "user_videos"=>0, "user_website"=>0, "user_work_history"=>0, "email"=>1, "read_friendlists"=>0, "read_insights"=>0, "read_mailbox"=>0, "read_requests"=>0, "read_stream"=>0, "xmpp_login"=>0, "ads_management"=>0, "user_checkins"=>0, "manage_pages"=>0}]
+
+      @request_regexp = /^SELECT ([\w,]*) FROM permissions WHERE uid = \d*$/
+    end
+
+    it "sends FQL with correct syntax when querying permissions" do
+      user_1.client.should_receive(:fql_query).with(@request_regexp).and_return @dummy_response
+      user_1.send :fetch_permissions
+    end
+
+    it "includes all known permissions in FQL query" do
+      user_1.client.should_receive(:fql_query) do |query|
+        @request_regexp =~ query
+        permissions_list = $1
+
+        Mogli::User::ALL_EXTENDED_PERMISSIONS.each do |perm|
+          query.should match /,?#{perm.to_s},?/
+        end
+
+        @dummy_response # stubbed return val
+      end
+
+      user_1.send :fetch_permissions
+    end
+
+    it "only submits permissions-checking FQL once when checking a permission" do
+      user_1.client.should_receive(:fql_query).once.and_return @dummy_response
+      user_1.has_permission? :publish_stream
+      user_1.has_permission? :offline_access
+    end
+
+    it "correctly converts FQL response into the permissions hash" do
+      user_1.client.should_receive(:fql_query).and_return @valid_response
+      user_1.send :fetch_permissions
+      Mogli::User::ALL_EXTENDED_PERMISSIONS.each do |perm|
+        user_1.extended_permissions.should be_include perm
+      end
+    end
+
+    it "correctly reports that user has permission they have granted" do
+      user_1.client.should_receive(:fql_query).and_return @valid_response
+      user_1.should be_has_permission(:offline_access)
+    end
+
+    it "correctly reports that user does not have permission they have not granted" do
+      user_1.client.should_receive(:fql_query).and_return @valid_response
+      user_1.should_not be_has_permission(:manage_pages)
+    end
+
+    it "should raise exception on unrecognized permission" do
+      lambda {
+        user_1.has_permission? :not_a_permission
+      }.should raise_error(Mogli::User::UnrecognizedExtendedPermissionException)
+    end
+  end
+
 end


### PR DESCRIPTION
Added a couple of methods to allow checking for extended permissions for a facebook user (e.g. to see if the user has dropped permissions on facebook while logged into your app): has_permission? and check_permissions.
