### PR TITLE
Facebook have changed Page fan_count to likes

### DIFF
--- a/lib/mogli/page.rb
+++ b/lib/mogli/page.rb
@@ -5,7 +5,7 @@ module Mogli
     define_properties :id, :name, :category, :username, :access_token
 
     # General
-    define_properties :fan_count, :link, :picture, :has_added_app
+    define_properties :likes, :link, :picture, :has_added_app, :website
 
     # Retail
     define_properties :founded, :products, :mission, :company_overview


### PR DESCRIPTION
updated Page attributes fan_count -> likes and added website, since Facebook have done away with fan_count.

Annoyingly broke our app when we validate at least 1 fan of a page, damn :)

Cheers

RobL
