### PR TITLE
A fix for NoMethodError 'has_key?' for HTTParty::Response

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -131,7 +131,7 @@ module Mogli
     def extract_hash_or_array(hash_or_array,klass)
       return nil if hash_or_array == false
       return hash_or_array if hash_or_array.nil? or hash_or_array.kind_of?(Array)
-      return extract_fetching_array(hash_or_array,klass) if hash_or_array.has_key?("data")
+      return extract_fetching_array(hash_or_array,klass) if hash_or_array.respond_to?(:has_key?) and hash_or_array.has_key?("data")
       return hash_or_array
     end
 

--- a/spec/app_client_spec.rb
+++ b/spec/app_client_spec.rb
@@ -8,33 +8,32 @@ describe Mogli::AppClient do
     end
     
     it "should allow you to subscribe with callback url, fields and verify token" do
-      Mogli::Client.should_receive(:post).with("http://graph.facebook.com/123/subscriptions",an_instance_of(Hash))
+      Mogli::AppClient.should_receive(:post).with("https://graph.facebook.com/123/subscriptions",an_instance_of(Hash))
       client.subscribe_to_model(Mogli::User,:callback_url=>"http://localhost:3000",:fields=>["username"])
     end
     
     it "should pass the type as the object field" do
-      Mogli::Client.should_receive(:post).with("http://graph.facebook.com/123/subscriptions",{:body=>hash_including(:object=>"user")})
+      Mogli::AppClient.should_receive(:post).with("https://graph.facebook.com/123/subscriptions",{:body=>hash_including(:object=>"user")})
       client.subscribe_to_model(Mogli::User,:callback_url=>"http://localhost:3000",:fields=>["username"])
     end
     
     it "sends the list of fields comma separated" do
-      Mogli::Client.should_receive(:post).with("http://graph.facebook.com/123/subscriptions",{:body=>hash_including(:fields=>"username,friends")})
+      Mogli::AppClient.should_receive(:post).with("https://graph.facebook.com/123/subscriptions",{:body=>hash_including(:fields=>"username,friends")})
       client.subscribe_to_model(Mogli::User,:callback_url=>"http://localhost:3000",:fields=>["username,friends"])
     end
     it "sends the callback url" do
-      Mogli::Client.should_receive(:post).with("http://graph.facebook.com/123/subscriptions",{:body=>hash_including(:callback_url=>"http://localhost:3000")})
+      Mogli::AppClient.should_receive(:post).with("https://graph.facebook.com/123/subscriptions",{:body=>hash_including(:callback_url=>"http://localhost:3000")})
       client.subscribe_to_model(Mogli::User,:callback_url=>"http://localhost:3000",:fields=>["username"])
     end
     
     it "should send the verify token if provided" do
-      Mogli::Client.should_receive(:post).with("http://graph.facebook.com/123/subscriptions",{:body=>hash_including(:verify_token=>"TOKEN")})
+      Mogli::AppClient.should_receive(:post).with("https://graph.facebook.com/123/subscriptions",{:body=>hash_including(:verify_token=>"TOKEN")})
       client.subscribe_to_model(Mogli::User,:callback_url=>"http://localhost:3000",:fields=>["username"],:verify_token=>"TOKEN")
-      
     end
     
     it "Lists the existing subscriptions" do
-     a.should_receive(:get_and_map_url).with("http://graph.facebook.com/123/subscriptions","Subscription")
-     a.subscriptions
+     client.should_receive(:get_and_map_url).with("https://graph.facebook.com/123/subscriptions","Subscription")
+     client.subscriptions
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -173,6 +173,10 @@ describe Mogli::Client do
     it "returns the raw value with no class specified" do
       client.map_data(user_data).should be_an_instance_of(Hash)
     end
+    
+    it "returns empty string if data is blank" do
+      client.map_data('').should == ''
+    end
 
     it "returns the array if no class is specified and there is only a data parameter" do
       client.map_data({"data"=>[user_data,user_data]}).should be_kind_of(Array)

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 class TestModel < Mogli::Model
   set_search_type :test_model
   define_properties :id, :other_property, :actions
-  creation_properties :other_property, :actions
+  creation_properties :actions, :other_property
   has_association :comments, "Comment"
 
   hash_populating_accessor :from, "User"


### PR DESCRIPTION
This is a fix for issue #30.  If the response from Facebook is blank then the HTTParty::Response parsed_response param will be blank and this error will occur.
