### PR TITLE
Removing reference to Hashie in model/search.rb

### DIFF
--- a/lib/mogli/model/search.rb
+++ b/lib/mogli/model/search.rb
@@ -1,5 +1,5 @@
 module Mogli
-  class Model < Hashie::Dash
+  class Model
     module Search
       attr_reader :search_type
 


### PR DESCRIPTION
Removed a reference to Hashie in model/search.rb which caused the following error:

.rvm/gems/ruby-1.8.7-p249/gems/mogli-0.0.24/lib/mogli/model/search.rb:2: uninitialized constant Mogli::Hashie (NameError)
