### PR TITLE
User#image_url override & additional User#image

### DIFF
--- a/lib/mogli/user.rb
+++ b/lib/mogli/user.rb
@@ -100,7 +100,7 @@ module Mogli
     end
     
     def image_url
-      begin
+      @image_url ||= begin
         client.class.get(client.api_path("#{id}/picture"), :query => client.default_params, :no_follow => true)
       rescue HTTParty::RedirectionTooDeep => e
         e.response["location"]

--- a/lib/mogli/user.rb
+++ b/lib/mogli/user.rb
@@ -99,13 +99,17 @@ module Mogli
       extended_permissions[permission]
     end
     
-    def image_url
-      @image_url ||= image(:url_only? => true)
+    def image_url(options = {})
+      @image_url ||= {}
+      @image_url[options] ||= image(options.merge({ :url_only? => true }))
     end
     
     def image(options = {})
       begin
-        response = client.class.get(client.api_path("#{id}/picture"), :query => client.default_params, :no_follow => options.delete(:url_only?))
+        response = client.class.get(client.api_path("#{id}/picture"), {
+          :no_follow  => options.delete(:url_only?),
+          :query      => client.default_params.merge(options) 
+        })
         Tempfile.new("mogli_user_image").tap { |image_file| image_file.write(response.body); image_file.close }
       rescue HTTParty::RedirectionTooDeep => e
         e.response["location"]

--- a/lib/mogli/user.rb
+++ b/lib/mogli/user.rb
@@ -98,6 +98,14 @@ module Mogli
 
       extended_permissions[permission]
     end
+    
+    def image_url
+      begin
+        client.class.get(client.api_path("#{id}/picture"), :query => client.default_params, :no_follow => true)
+      rescue HTTParty::RedirectionTooDeep => e
+        e.response["location"]
+      end
+    end
 
     private
 

--- a/lib/mogli/user.rb
+++ b/lib/mogli/user.rb
@@ -100,8 +100,13 @@ module Mogli
     end
     
     def image_url
-      @image_url ||= begin
-        client.class.get(client.api_path("#{id}/picture"), :query => client.default_params, :no_follow => true)
+      @image_url ||= image(:url_only? => true)
+    end
+    
+    def image(options = {})
+      begin
+        response = client.class.get(client.api_path("#{id}/picture"), :query => client.default_params, :no_follow => options.delete(:url_only?))
+        Tempfile.new("mogli_user_image").tap { |image_file| image_file.write(response.body); image_file.close }
       rescue HTTParty::RedirectionTooDeep => e
         e.response["location"]
       end


### PR DESCRIPTION
Hey Mike,

it seems that fb no longer serves actual user images under https://graph.facebook.com/USERID/picture but instead requires the inclusion of an access token in requests to this URL. It will then respond with a 302 pointing to the _actual_ image file.

Please have a look at the attached patches which override User#image_url to take this into account. I also added User#image to allow for direct retreival of the file itself; handy for instance if you want to crop it into dimensions other than those provided by facebook.

I haven't added tests yet since I'm not entirely settled on the API. Unfortunately some HTTParty quirks also led to somewhat ugly code. So feedback is appreciated!

Cheers,
Niels
