### PR TITLE
Add support to call api methods with custom url and with post method 

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -97,7 +97,7 @@ module Mogli
       map_data(data,klass)
     end
     
-    def post_to_url(url,klass,body_args)
+    def post_to_url(url,klass,body_args={})
       data = self.class.post(url,:body=>default_params.merge(body_args))
       map_data(data,klass)
     end

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -96,6 +96,11 @@ module Mogli
       data = self.class.post(api_path(path),:body=>default_params.merge(body_args))
       map_data(data,klass)
     end
+    
+    def post_to_url(url,klass,body_args)
+      data = self.class.post(url,:body=>default_params.merge(body_args))
+      map_data(data,klass)
+    end
 
     def delete(path)
       self.class.delete(api_path(path),:query=>default_params)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -141,6 +141,14 @@ describe Mogli::Client do
         result = client.post("1/feed","Post",:message=>"message")
       end.should raise_error(Mogli::Client::FeedActionRequestLimitExceeded, error_message)
     end
+    
+    it "posts to a url as a parameter" do
+      Mogli::Client.should_receive(:post).with("http://cool-tabs.com", :body=>{:access_token=>"1234"}).and_return({:id=>123434})
+      client = Mogli::Client.new("1234")
+      result = client.post_to_url("http://cool-tabs.com","Post",{})
+      result.should == Mogli::Post.new(:id=>123434)
+    end
+    
 
   end
 


### PR DESCRIPTION
By default, post method in Mogli::Client uses "https://graph.facebook.com/" as api_path, but sometimes is useful use another "base path" to make calls (for example, to customize an Mogli::Application properties)
