### PR TITLE
Mike, please take a look at my pull request.

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -141,7 +141,7 @@ module Mogli
       return nil if hash_or_array == false
       return hash_or_array if hash_or_array.nil? or hash_or_array.kind_of?(Array)
       hash_or_array = hash_or_array.parsed_response if hash_or_array.respond_to?(:parsed_response)
-      return extract_fetching_array(hash_or_array,klass) if is_fetching_array?(hash_or_array)
+      return extract_fetching_array(hash_or_array,klass) if hash_or_array and is_fetching_array?(hash_or_array)
       return hash_or_array
     end
     
@@ -162,7 +162,7 @@ module Mogli
     end
 
     def map_to_class(hash_or_array,klass)
-      return nil if hash_or_array.nil?
+      return nil if !hash_or_array
       if hash_or_array.kind_of?(Array)
         hash_or_array.map! {|i| create_instance(klass,i)}
       else

--- a/lib/mogli/page.rb
+++ b/lib/mogli/page.rb
@@ -1,7 +1,7 @@
 module Mogli
   class Page < Profile
         
-    define_properties :id, :name, :category, :username
+    define_properties :id, :name, :category, :username, :access_token
     
     # General
     define_properties :fan_count, :link, :picture, :has_added_app
@@ -12,6 +12,21 @@ module Mogli
     # Musicians
     define_properties :record_label, :hometown, :band_members, :genre
     
+	# When "/me/accounts" returns Page with 'access_token', this Page can be
+	# impersonated by an application.  The expiration value must be taken from
+	# the caller object (e.g., User) so as to uphold the original permissions.
+	def initialize(hash = {}, client = nil)
+		super(hash, client)
+		unless(access_token.blank?)
+			if(client.blank?)
+				self.client = Mogli::Client.new(access_token)
+			else
+				self.client =
+				Mogli::Client.new(access_token, client.expiration)
+			end
+		end
+	end
+
     def self.recognize?(hash)
       hash.has_key?("category")
     end


### PR DESCRIPTION
Hi, Mike:

I traced the situation when Mogli::Page.find(page_id) fails to find the Facebook Page that in fact exists.  The manifestation of this problem was that hash_or_array in client.rb was 'false', which crashed on "has_key" and "key" in the respective methods.  I added a couple of simple checks to prevent this null pointer exception.

Here are the example of Facebook Pages to demonstrate the inconsistency (the dollar signs are delimiters I use for clarity when printing to stdout):

Case A. Mogli::Page.find does the right thing:
Facebook Page URL=$http://www.facebook.com/crackle$
Mogli::Page.find('/crackle') returns
FB_PAGE=$Crackle$
NUM_LIKES=$35475$

Case B. Mogli::Page.find does not find the Facebook Page:
Facebook Page URL=$http://www.facebook.com/AllClearID$
Mogli::Page.find('/AllClearID') returns
[2011/04/13:17:31:35] FB_PAGE=$$

I also hit the Facebook Open Graph HTTP API to try to see what is going on and found that https://graph.facebook.com/AllClearID returns 'false' on a page, instead of the JSON for that page.

Hence, I believe that this is not the fault of Mogli -- 'hash_or_array.parsed_response" comes up as 'false' for a perfectly valid Facebook Page, because https://graph.facebook.com/AllClearID returns 'false' that page.

At this point, I am wondering who might be able to shed some light on this.  I am going to contact the owners of that page and ask them if they -- somehow -- disabled API access for their company page (which would seem odd, assuming that Facebook even makes it possible).  

Overall, for a vast majority of Facebook Pages, the data is returned as expected.  However, for  a small number of Facebook Pages, I consistently get a null result back.

Thank you for your help and your time.

Sincerely,
--Alex
