### PR TITLE
Rename creation query parameter, document creation params

### DIFF
--- a/lib/mogli/test_user.rb
+++ b/lib/mogli/test_user.rb
@@ -12,16 +12,34 @@ module Mogli
   class TestUser < User
     define_properties :access_token, :login_url, :password
 
-    def self.create(query, app_client)
-      app_client.post("accounts/test-users", self, query)
+    # test_user_params can include:
+    #
+    # installed: This is a Boolean parameter to specify whether your
+    # app should be installed for the test user at the time of
+    # creation. It is true by default.
+    #
+    # name: this is an optional string parameter. You can specify a
+    # name for the test user you create. The specified name will also
+    # be used in the email address assigned to the test user.
+    #
+    # permissions: This is a comma-separated list of {extended permissions}[http://developers.facebook.com/docs/reference/api/permissions/].
+    # Your app is granted these permissions for the new test user if
+    # installed is true.
+    #
+    # Example usage:
+    #
+    # Mogli::TestUser.create({:installed => false, :name => 'Zark Muckerberg', :permissions => 'user_events,create_event'}, client)
+    def self.create(test_user_params, app_client)
+      app_client.post("accounts/test-users", self, test_user_params)
     end
 
-    def self.all(query, app_client)
-      app_client.get_and_map("accounts/test-users", self, query)
+    def self.all(app_client)
+      app_client.get_and_map("accounts/test-users", self, {})
     end
 
     def to_s
-      id
+      # name is nil by default, so use id
+      id.to_s
     end
   end
 end

--- a/spec/test_user_spec.rb
+++ b/spec/test_user_spec.rb
@@ -7,8 +7,9 @@ describe Mogli::User do
   describe "#create" do
     it "POSTs to the test user creation url" do
       Mogli::Client.should_receive(:post).with("https://graph.facebook.com/#{app_id}/accounts/test-users",
-        :body => {:access_token => access_token}).and_return({:id=>1, :login_url => 'http://example.com/hamsocks' })
-      user = Mogli::TestUser.create({}, Mogli::AppClient.new(access_token, app_id))
+        :body => {:access_token => access_token, :installed => false, :name => 'The Sock Hammer'}).
+        and_return({:id=>1, :login_url => 'http://example.com/hamsocks' })
+      user = Mogli::TestUser.create({:installed => false, :name => 'The Sock Hammer'}, Mogli::AppClient.new(access_token, app_id))
       user.login_url.should == 'http://example.com/hamsocks'
     end
   end
@@ -17,7 +18,7 @@ describe Mogli::User do
     it "GETs the test user url" do
       Mogli::Client.should_receive(:get).with("https://graph.facebook.com/#{app_id}/accounts/test-users",
         :query => {:access_token => access_token}).and_return([{:id=>1, :login_url => 'http://example.com/hamsocks'}])
-      users = Mogli::TestUser.all({}, Mogli::AppClient.new(access_token, app_id))
+      users = Mogli::TestUser.all(Mogli::AppClient.new(access_token, app_id))
       users.first.login_url.should == 'http://example.com/hamsocks'
     end
   end


### PR DESCRIPTION
Doco ripped shamelessly from:

http://developers.facebook.com/docs/test_users/

Also, drop query parameter on TestUser#all, as there are no documented options.
