### PR TITLE
Fix two bugs in session_key -> access_token exchange

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -86,10 +86,15 @@ module Mogli
 
     def self.create_from_session_key(session_key, client_id, secret)
       authenticator = Mogli::Authenticator.new(client_id, secret, nil)
+
       access_data =
         authenticator.get_access_token_for_session_key(session_key) || {}
-      new(access_data['access_token'],
-          Time.now.to_i + access_data['expires'].to_i)
+
+      expires = if access_data['expires']
+        Time.now.to_i + access_data['expires'].to_i
+      end
+
+      new(access_data['access_token'], expires)
     end
     
     def self.create_and_authenticate_as_application(client_id, secret)

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -86,7 +86,8 @@ module Mogli
 
     def self.create_from_session_key(session_key, client_id, secret)
       authenticator = Mogli::Authenticator.new(client_id, secret, nil)
-      access_data = authenticator.get_access_token_for_session_key(session_key)
+      access_data =
+        authenticator.get_access_token_for_session_key(session_key) || {}
       new(access_data['access_token'],
           Time.now.to_i + access_data['expires'].to_i)
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -36,6 +36,19 @@ describe Mogli::Client do
       client.access_token.should == '123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo'
     end
 
+    it "doesn't bail when the session key is stale" do
+      Time.stub!(:now).and_return(1270000000)
+      authenticator = Mogli::Authenticator.new('123456', 'secret', nil)
+      authenticator.should_receive(:get_access_token_for_session_key).
+                    with('mysessionkey').
+                    and_return(nil)
+      Mogli::Authenticator.should_receive(:new).and_return(authenticator)
+      lambda {
+        client = Mogli::Client.create_from_session_key(
+                   'mysessionkey', '123456', 'secret')
+      }.should_not raise_exception(NoMethodError, /nil/)
+    end
+
     it "sets the access_token into the default params" do
       client = Mogli::Client.new("myaccesstoken")
       client.default_params.should == {:access_token=>"myaccesstoken"}


### PR DESCRIPTION
- Create an empty client when the session key has expired
- Handle clients that don't expire
