### PR TITLE
Some various fixes about to some responses we are getting from Facebook.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://www.rubygems.org"
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,30 @@
 require 'rake'
 require 'rubygems'
-gem 'rspec'
-require 'spec/rake/spectask'
- 
+
+begin
+  require 'spec'
+  version = 1
+rescue LoadError => e
+  require 'rspec'
+  version = 2
+end
+
 desc 'Default: run unit tests.'
 task :default => :spec
- 
-desc 'Test the  plugin.'
-Spec::Rake::SpecTask.new(:spec) do |t|
-  t.libs << 'lib'
-  t.verbose = true
+
+# So it can we used for both versions of rspec
+if version <= 1
+  require 'spec/rake/spectask'
+  desc 'Test the  plugin.'
+  Spec::Rake::SpecTask.new(:spec) do |t|
+    t.libs << 'lib'
+    t.verbose = true
+  end
+else
+  require 'rspec/core/rake_task'
+  desc 'Test the  plugin.'
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.verbose = true
+  end
 end
+

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -201,12 +201,12 @@ module Mogli
     end
 
     def raise_error_if_necessary(data)
-      raise HTTPException if data.respond_to?(:code) and data.code != 200
       if data.kind_of?(Hash)
         if data.keys.size == 1 and data["error"]
           self.class.raise_error_by_type_and_message(data["error"]["type"], data["error"]["message"])
         end
       end
+      raise HTTPException if data.respond_to?(:code) and data.code != 200
     end
 
     def fields_to_serialize

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -146,7 +146,8 @@ module Mogli
 
     def extract_hash_or_array(hash_or_array,klass)
       hash_or_array = hash_or_array.parsed_response if hash_or_array.respond_to?(:parsed_response)
-      return nil if hash_or_array == false
+      return nil if hash_or_array == false || hash_or_array == true
+
       return hash_or_array if hash_or_array.nil? or hash_or_array.kind_of?(Array)
       return extract_fetching_array(hash_or_array,klass) if is_fetching_array?(hash_or_array)
       return hash_or_array

--- a/lib/mogli/page.rb
+++ b/lib/mogli/page.rb
@@ -16,6 +16,9 @@ module Mogli
     # As a like
     define_properties :created_time
 
+    # Number of checkins, not Checkin assocciation.
+    define_properties :checkins
+
     def client_for_page
       if access_token.blank?
         raise MissingAccessToken.new("You can only get a client for this page if an access_token has been provided. i.e. via /me/accounts")

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -10,4 +10,7 @@ spec = Gem::Specification.new do |s|
   s.email = "mmangino@elevatedrails.com"
   s.homepage = "http://developers.facebook.com/docs/api"
   s.add_dependency('httparty', ">=0.4.3")
+  s.add_dependency('hashie', "~> 1.0.0")
+  s.add_development_dependency "rspec", "~> 2"
+  s.add_development_dependency "rake"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -284,6 +284,11 @@ describe Mogli::Client do
       client.get_and_map(148800401968,"User").should be_nil
     end
 
+    it "returns nil if Facebook says true" do
+      Mogli::Client.should_receive(:get).and_return(true)
+      client.get_and_map(148800401968,"User").should be_nil
+    end
+    
     it "raises an exception with specific message when there is just an error" do
       lambda do
         client.map_data({"error"=>{"type"=>"OAuthAccessTokenException","message"=>"An access token is required to request this resource."}})

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -109,6 +109,18 @@ describe Mogli::Client do
         result = client.post("1/feed","Post",:message=>"message")
       end.should raise_error(Mogli::Client::OAuthAccessTokenException, "An access token is required to request this resource.")
     end
+
+    it "parses errors in the returns of posts, even when response code is not 200" do
+      error = {"type"=>"OAuthAccessTokenException","message"=>"An access token is required to request this resource."}
+      mock_response = mock("response", :code => 500, :kind_of? => true,
+        :keys => mock("keys", :size => 1), :[] => error)
+      Mogli::Client.should_receive(:post).and_return(mock_response)
+      client = Mogli::Client.new("1234")
+      lambda do
+        result = client.post("1/feed","Post",:message=>"message")
+      end.should raise_error(Mogli::Client::OAuthAccessTokenException, "An access token is required to request this resource.")
+    end
+
     
     it "parses http response errors" do
       Mogli::Client.should_receive(:post).and_return(mock("httpresponse",:code=>500))

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -16,4 +16,14 @@ describe Mogli::Page do
     client = page.client_for_page
     client.access_token.should == "my token"
   end
+
+  it "should not raise an error when FB returns # of checkins in page data" do
+    Mogli::Client.stub!(:get).and_return({:id=>1, :checkins => 999})
+    page = Mogli::Page.new(:id => 1)
+    lambda do
+      page.fetch
+    end.should_not raise_error(NoMethodError)
+    page.checkins.should == 999
+  end
+
 end


### PR DESCRIPTION
All of them have tests included :)
- Even when response code is != 200, try to read error class and message.
  
  It helps you see what the problem with a request might be.
- When FB returns just "true", don't break.
  
  It returns true, for example, when updating a Tab's name.
- When FB returns # of checkins in Page data, we should not fail
