### PR TITLE
Require 'multi-json' before 'json'

### DIFF
--- a/lib/mogli/post.rb
+++ b/lib/mogli/post.rb
@@ -1,3 +1,4 @@
+require 'multi_json'
 require 'json'
 
 module Mogli


### PR DESCRIPTION
In Rails using everything but 1.9.2 the build was failing - http://travis-ci.org/#!/codeforamerica/JobOps/builds/94658

$ bundle exec rake db:migrate
rake aborted!
no such file to load -- json

Loading the multi_json gem before json gem should make this pass on versions other than 1.9.2 running Rails.

Also the .gemspec file still says 0.0.28, I did not update in this pull request.  
