### PR TITLE
Fixes Issue 68 -- InvalidURIError

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -174,8 +174,8 @@ module Mogli
       f.client = self
       f.classes = Array(klass)
       if hash["paging"]
-        f.next_url = hash["paging"]["next"]
-        f.previous_url = hash["paging"]["previous"]
+        f.next_url = URI.encode hash["paging"]["next"]
+        f.previous_url = URI.encode hash["paging"]["previous"]
       end
       f
     end


### PR DESCRIPTION
URLs with oauth tokens containing certain characters would issue a `URI::InvalidURIError`. Now `next_url` and `previous_url` are [encoded](http://www.ruby-doc.org/stdlib/libdoc/uri/rdoc/classes/URI/Escape.html).
