### PR TITLE
Added missing cover_photo property

### DIFF
--- a/lib/mogli/album.rb
+++ b/lib/mogli/album.rb
@@ -1,7 +1,7 @@
 module Mogli
   class Album < Model
     
-    define_properties :id, :name, :description, :location, :privacy, :link, :count, :created_time, :updated_time
+    define_properties :id, :name, :description, :location, :cover_photo, :privacy, :link, :count, :created_time, :updated_time
     creation_properties :name, :description
     
     hash_populating_accessor :from, "User","Page"


### PR DESCRIPTION
Added the `cover_photo` property to the `Album` model. This returns the id of the photo's cover photo, but not the actual photo object itself.

There's room for a possible `has_association` to the the Photo model, but I'm not quite sure how to go about it...
