### PR TITLE
Fix session key <-> access token exchange

### DIFF
--- a/lib/mogli/authenticator.rb
+++ b/lib/mogli/authenticator.rb
@@ -24,13 +24,17 @@ module Mogli
       keystr = session_keys.is_a?(Array) ?
                  session_keys.join(',') : session_keys
       client = Mogli::Client.new
-      response = client.post("oauth/exchange_sessions", nil,
-                  {:type => 'client_cred',
-                   :client_id => client_id,
-                   :client_secret => secret,
-                   :sessions => keystr})
+      response = client.class.post(client.api_path("oauth/exchange_sessions"),
+        :body => {
+          :type => 'client_cred',
+          :client_id => client_id,
+          :client_secret => secret,
+          :sessions => keystr
+        }
+      )
       raise_exception_if_required(response)
-      response
+      tokens = response.parsed_response
+      session_keys.is_a?(Array) ? tokens : tokens.first
     end
     
     def get_access_token_for_application

--- a/lib/mogli/authenticator.rb
+++ b/lib/mogli/authenticator.rb
@@ -47,7 +47,7 @@ module Mogli
         }
       )
       raise_exception_if_required(response)
-      response.to_s.split("=").last
+      response.parsed_response.split("=").last
     end
     
     def raise_exception_if_required(response)

--- a/spec/authenticator_spec.rb
+++ b/spec/authenticator_spec.rb
@@ -74,8 +74,10 @@ describe Mogli::Authenticator do
   end
 
   it "can ask for an application token" do
-    response = "access_token=123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo"
-    response.stub!(:code).and_return(200)
+    response = mock('HTTParty::Response',
+      :parsed_response => "access_token=123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo",
+      :code => 200)
+
     Mogli::Client.should_receive(:post).
       with("https://graph.facebook.com/oauth/access_token",
            :body=> {
@@ -91,8 +93,10 @@ describe Mogli::Authenticator do
   end
 
   it "raises an error if not a 200" do
-    response = "access_token=123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo"
-    response.stub!(:code).and_return(500)
+    response = mock('HTTParty::Response',
+      :parsed_response => "access_token=123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo",
+      :code => 500)
+
     Mogli::Client.should_receive(:post).and_return(response)
     lambda do
       token = authenticator.get_access_token_for_application

--- a/spec/authenticator_spec.rb
+++ b/spec/authenticator_spec.rb
@@ -30,8 +30,12 @@ describe Mogli::Authenticator do
   end
 
   it "can trade session_keys for access_tokens" do
-    response = [{"access_token" => "myaccesstoken",   "expires" => 5000},
-                {"access_token" => "youraccesstoken", "expires" => 5000}]
+    response = mock('HTTParty::Response',
+      :parsed_response => [
+          {"access_token" => "myaccesstoken",   "expires" => 5000},
+          {"access_token" => "youraccesstoken", "expires" => 5000}
+        ],
+      :code => 200)
     response.stub!(:code).and_return(200)
 
     Mogli::Client.should_receive(:post).
@@ -47,20 +51,28 @@ describe Mogli::Authenticator do
                  {"access_token" => "youraccesstoken", "expires" => 5000}]
   end
 
-  it "can trade one session_key for an access_tokens" do
-    response = {"access_token" => "myaccesstoken", "expires" => 5000}
-    response.stub!(:code).and_return(200)
+  it "can trade one session_key for an access_token" do
+    response = mock('HTTParty::Response',
+      :parsed_response => [
+          {"access_token" => "myaccesstoken", "expires" => 5000}
+        ],
+      :code => 200)
+
     Mogli::Client.should_receive(:post).
       with("https://graph.facebook.com/oauth/exchange_sessions",
-           :body => {:type => "client_cred", :client_id => "123456",
-                     :client_secret => "secret", :sessions => "mysessionkey"}).
+           :body => {
+             :type => "client_cred",
+             :client_id => "123456",
+             :client_secret => "secret",
+             :sessions => "mysessionkey"
+          }).
       and_return(response)
 
     authenticator.
       get_access_token_for_session_key("mysessionkey").
       should == {"access_token" => "myaccesstoken", "expires" => 5000}
   end
-  
+
   it "can ask for an application token" do
     response = "access_token=123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo"
     response.stub!(:code).and_return(200)
@@ -72,12 +84,12 @@ describe Mogli::Authenticator do
              :client_secret => "secret"
            }).
       and_return(response)
-      
-      
+
+
       token = authenticator.get_access_token_for_application
       token.should =="123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo"
   end
-  
+
   it "raises an error if not a 200" do
     response = "access_token=123456|3SDdfgdfgv0bbEvYjBH5tJtl-dcBdsfgo"
     response.stub!(:code).and_return(500)
@@ -85,7 +97,7 @@ describe Mogli::Authenticator do
     lambda do
       token = authenticator.get_access_token_for_application
     end.should raise_error(Mogli::Client::HTTPException)
-    
+
   end
 
   context "Oauth2" do


### PR DESCRIPTION
Before HTTParty changed its response type to `HTTParty::Response`, exchanging a single session key for an access token would return the token as a hash, but now it behaves like an array with a single element. The behavior when exchanging multiple keys at once hasn't changed.

This changeset updates session exchange to handle the new response, then updates fetching an application's token to look the same, since `#parsed_response` is more semantic and generally applicable than `#tos`.
