### PR TITLE
Stop relying on `blank?`

### DIFF
--- a/lib/mogli/authenticator.rb
+++ b/lib/mogli/authenticator.rb
@@ -17,7 +17,7 @@ module Mogli
     end
 
     def access_token_url(code)
-      "https://graph.facebook.com/oauth/access_token?client_id=#{client_id}&redirect_uri=#{CGI.escape(callback_url) if !callback_url.blank?}&client_secret=#{secret}&code=#{CGI.escape(code)}"
+      "https://graph.facebook.com/oauth/access_token?client_id=#{client_id}&redirect_uri=#{CGI.escape(callback_url) unless callback_url.nil? || callback_url.empty?}&client_secret=#{secret}&code=#{CGI.escape(code)}"
     end
 
     def get_access_token_for_session_key(session_keys)
@@ -32,7 +32,7 @@ module Mogli
       raise_exception_if_required(response)
       response
     end
-    
+
     def get_access_token_for_application
       client = Mogli::Client.new
       response = client.class.post(client.api_path('oauth/access_token'),
@@ -45,7 +45,7 @@ module Mogli
       raise_exception_if_required(response)
       response.to_s.split("=").last
     end
-    
+
     def raise_exception_if_required(response)
       raise Mogli::Client::HTTPException if response.code != 200
     end

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -84,7 +84,7 @@ module Mogli
 
     def self.response_is_error?(post_data)
        post_data.kind_of?(Hash) and
-       !post_data["error"].blank?
+       !post_data["error"].empty?
     end
 
     def self.create_from_session_key(session_key, client_id, secret)
@@ -92,12 +92,12 @@ module Mogli
       access_data = authenticator.get_access_token_for_session_key(session_key)
       new(access_token_from_access_data(access_data),expiration_from_access_data(access_data))
     end
-    
+
     def self.access_token_from_access_data(access_data)
       return nil if access_data.nil?
       access_data['access_token']
     end
-    
+
     def self.expiration_from_access_data(access_data)
       return nil if access_data.nil? or access_data['expires'].nil?
       Time.now.to_i + access_data['expires'].to_i

--- a/lib/mogli/fetching_array.rb
+++ b/lib/mogli/fetching_array.rb
@@ -1,17 +1,17 @@
 module Mogli
   class FetchingArray < Array
     attr_accessor :next_url, :previous_url, :client, :classes
-    
+
     def fetch_next
-      return [] if next_url.blank?
+      return [] if next_url.nil? || next_url.empty?
       additions = client.get_and_map_url(next_url,classes)
       self.next_url = additions.next_url
       self.concat(additions)
       additions
     end
-    
+
     def fetch_previous
-      return [] if previous_url.blank?
+      return [] if previous_url.nil? || previous_url.empty?
       additions = client.get_and_map_url(previous_url,classes)
       self.previous_url = additions.previous_url
       self.unshift(*additions)

--- a/lib/mogli/page.rb
+++ b/lib/mogli/page.rb
@@ -17,7 +17,7 @@ module Mogli
     define_properties :created_time
 
     def client_for_page
-      if access_token.blank?
+      if access_token.nil? || access_token.empty?
         raise MissingAccessToken.new("You can only get a client for this page if an access_token has been provided. i.e. via /me/accounts")
       end
       Client.new(access_token)


### PR DESCRIPTION
`blank?` was available on Strings, Hashes, etc. because the crack gem added it, but HTTParty doesn't depend on crack as of v0.8.0. Checking `nil?` and `empty?` is more verbose and a little irritating, but will be more dependable.
