### PR TITLE
add missing properties on Comment Page and Post

### DIFF
--- a/lib/mogli/comment.rb
+++ b/lib/mogli/comment.rb
@@ -1,7 +1,7 @@
 module Mogli
   class Comment < Model
     
-    define_properties :id, :message, :created_time
+    define_properties :id, :message, :created_time, :likes
     creation_properties :message
     hash_populating_accessor :from, "User","Page"
     

--- a/lib/mogli/page.rb
+++ b/lib/mogli/page.rb
@@ -5,7 +5,7 @@ module Mogli
     define_properties :id, :name, :category, :username, :access_token
 
     # General
-    define_properties :likes, :link, :picture, :has_added_app, :website, :description, :can_post, :checkins
+    define_properties :likes, :link, :picture, :has_added_app, :website, :description, :can_post, :checkins, :general_info
 
     # Retail
     define_properties :founded, :products, :mission, :company_overview

--- a/lib/mogli/post.rb
+++ b/lib/mogli/post.rb
@@ -6,7 +6,7 @@ module Mogli
 
     define_properties :id, :to, :message, :picture, :link, :name, :caption,
       :description, :source, :icon, :attribution, :actions, :likes,
-      :created_time, :updated_time, :privacy, :type
+      :created_time, :updated_time, :privacy, :type, :object_id, :properties
 
     creation_properties :message, :picture, :link, :name, :description, :caption, :source, :actions, :privacy
 


### PR DESCRIPTION
Sorry for this third pull request ...

But this time be careful there is a property named `object_id` on `Post`.
I've defined it but it seem's a bit shitty.
