### PR TITLE
Fix HTTPException to not be thrown on every Facebook error

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -212,12 +212,12 @@ module Mogli
     end
 
     def raise_error_if_necessary(data)
-      raise HTTPException if data.respond_to?(:code) and data.code != 200 and data.code != 400
       if data.kind_of?(Hash)
         if data.keys.size == 1 and data["error"]
           self.class.raise_error_by_type_and_message(data["error"]["type"], data["error"]["message"])
         end
       end
+      raise HTTPException if data.respond_to?(:code) and data.code != 200 and data.code != 400
     end
 
     def fields_to_serialize


### PR DESCRIPTION
When a Facebook occurs on Graph API calls, the server replies with a 403 HTTP error code. Thus mogli would always throw a HTTPException without any further information on it (thrown by raise_error_if_necessary).
By first checking the response body for an error message and type, we make sure that we get proper exceptions in all cases.
