### PR TITLE
Better exception handling due to invalid session; add additional properties

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -212,7 +212,7 @@ module Mogli
     end
 
     def raise_error_if_necessary(data)
-      raise HTTPException.new("HTTPException, data=>#{data.inspect}") if data.respond_to?(:code) and data.code != 200
+      raise HTTPException.new("data=>#{data.inspect}") if data.respond_to?(:code) and data.code != 200
       if data.kind_of?(Hash)
         if data.keys.size == 1 and data["error"]
           self.class.raise_error_by_type_and_message(data["error"]["type"], data["error"]["message"])

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -212,7 +212,7 @@ module Mogli
     end
 
     def raise_error_if_necessary(data)
-      raise HTTPException if data.respond_to?(:code) and data.code != 200
+      raise HTTPException.new("HTTPException, data=>#{data.inspect}") if data.respond_to?(:code) and data.code != 200
       if data.kind_of?(Hash)
         if data.keys.size == 1 and data["error"]
           self.class.raise_error_by_type_and_message(data["error"]["type"], data["error"]["message"])

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -73,7 +73,7 @@ module Mogli
     def self.raise_error_by_type_and_message(type, message)
       if type == 'OAuthException' && message =~ /Feed action request limit reached/
         raise FeedActionRequestLimitExceeded.new(message)
-      elsif type == 'OAuthException' && message =~ /The session has been invalidated because the user has changed the password/
+      elsif type == 'OAuthException' && (message =~ /The session has been invalidated because the user has changed the password/ || message =~ /Session does not match current stored session/)
         raise SessionInvalidatedDueToPasswordChange.new(message)
       elsif Mogli::Client.const_defined?(type)
         raise Mogli::Client.const_get(type).new(message)
@@ -212,7 +212,7 @@ module Mogli
     end
 
     def raise_error_if_necessary(data)
-      raise HTTPException.new("data=>#{data.inspect}") if data.respond_to?(:code) and data.code != 200
+      raise HTTPException.new("data=>#{data.inspect}") if data.respond_to?(:code) and ![200, 400].include?(data.code)
       if data.kind_of?(Hash)
         if data.keys.size == 1 and data["error"]
           self.class.raise_error_by_type_and_message(data["error"]["type"], data["error"]["message"])

--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -212,7 +212,7 @@ module Mogli
     end
 
     def raise_error_if_necessary(data)
-      raise HTTPException.new("data=>#{data.inspect}") if data.respond_to?(:code) and ![200, 400].include?(data.code)
+      raise HTTPException.new("data=>#{data.inspect}") if data.respond_to?(:code) and !(400..499).include?(data.code) and data.code != 200
       if data.kind_of?(Hash)
         if data.keys.size == 1 and data["error"]
           self.class.raise_error_by_type_and_message(data["error"]["type"], data["error"]["message"])

--- a/lib/mogli/photo.rb
+++ b/lib/mogli/photo.rb
@@ -1,7 +1,7 @@
 module Mogli
   class Photo < Model
     define_properties :id, :name, :tags, :picture, :source, :height, :width, :images, :link, :icon,
-      :created_time, :updated_time, :position, :comments
+      :created_time, :updated_time, :position, :comments, :likes
     creation_properties :message
 
     hash_populating_accessor :from, "User","Page"

--- a/lib/mogli/status.rb
+++ b/lib/mogli/status.rb
@@ -1,6 +1,6 @@
 module Mogli
   class Status < Model
-    define_properties :id, :message, :updated_time, :created_time, :likes
+    define_properties :id, :message, :updated_time, :created_time, :comments, :likes
 
     hash_populating_accessor :from, "User", "Page"
 

--- a/lib/mogli/status.rb
+++ b/lib/mogli/status.rb
@@ -1,6 +1,6 @@
 module Mogli
   class Status < Model
-    define_properties :id, :message, :updated_time, :created_time
+    define_properties :id, :message, :updated_time, :created_time, :comments, :likes
 
     hash_populating_accessor :from, "User", "Page"
   end

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.28.0.copious'
+  s.version = '0.0.28.1.copious'
   s.summary = "Open Graph Library for Ruby"
   s.description = %{Simple library for accessing the facebook Open Graph API}
   s.files = Dir['lib/**/*.rb']

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.33.4.copious'
+  s.version = '0.0.33.5.copious'
   s.summary = 'Open Graph Library for Ruby'
   s.description = 'Simple library for accessing the Facebook Open Graph API'
   s.files = Dir['lib/**/*.rb']

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.36.1.copious'
+  s.version = '0.0.36'
   s.summary = 'Open Graph Library for Ruby'
   s.description = 'Simple library for accessing the Facebook Open Graph API'
   s.files = Dir['lib/**/*.rb']
@@ -16,5 +16,4 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'stickler', [">= 2.0"]
 end

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.33.1.copious'
+  s.version = '0.0.33.2.copious'
   s.summary = 'Open Graph Library for Ruby'
   s.description = 'Simple library for accessing the Facebook Open Graph API'
   s.files = Dir['lib/**/*.rb']

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.33.2.copious'
+  s.version = '0.0.33.3.copious'
   s.summary = 'Open Graph Library for Ruby'
   s.description = 'Simple library for accessing the Facebook Open Graph API'
   s.files = Dir['lib/**/*.rb']

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.28'
+  s.version = '0.0.28.0.copious'
   s.summary = "Open Graph Library for Ruby"
   s.description = %{Simple library for accessing the facebook Open Graph API}
   s.files = Dir['lib/**/*.rb']

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -9,7 +9,8 @@ spec = Gem::Specification.new do |s|
   s.author = 'Mike Mangino'
   s.email = 'mmangino@elevatedrails.com'
   s.homepage = 'http://developers.facebook.com/docs/api'
-  s.add_dependency 'hashie', '~> 1.1.0'
+  # the specific version of hashie doesn't seem to be required, at least from the light testing I've done
+  s.add_dependency 'hashie'#, '~> 1.1.0'
   s.add_dependency 'httparty', '>= 0.4.3'
   s.add_dependency 'multi_json', '~> 1.0.3'
   s.add_development_dependency 'json'

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -16,4 +16,5 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'stickler', [">= 2.0"]
 end

--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.33.3.copious'
+  s.version = '0.0.33.4.copious'
   s.summary = 'Open Graph Library for Ruby'
   s.description = 'Simple library for accessing the Facebook Open Graph API'
   s.files = Dir['lib/**/*.rb']

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -172,6 +172,18 @@ describe Mogli::Client do
       end.should raise_error(Mogli::Client::SessionInvalidatedDueToPasswordChange, err_msg)
     end
 
+    it "parses a failure due to user permissions" do
+      err_type="OAuthException"
+      err_msg ="(#210) User not visible"
+      response={"error"=>{"type"=>err_type,"message"=>err_msg}}
+      mock_response = mock("response",:parsed_response=>response,:code=>403,:kind_of? => true,:keys => ["error"],:[] => response["error"])
+      Mogli::Client.should_receive(:post).and_return(mock_response)
+      client = Mogli::Client.new("1234")
+      lambda do
+        result = client.post("1/feed","Post",:message=>"message")
+      end.should raise_error(Mogli::Client::OAuthException, err_msg)
+    end
+
     it "raises specific exception if Facebook-imposed posting limit exceeded for feed" do
       error_message = "Feed action request limit reached"
       Mogli::Client.should_receive(:post).and_return({"error"=>{"type"=>"OAuthException","message"=>error_message}})
@@ -360,5 +372,4 @@ describe Mogli::Client do
       end
     end
   end
-
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -136,14 +136,13 @@ describe Mogli::Client do
         result = client.post("1/feed","Post",:message=>"message")
       end.should raise_error(Mogli::Client::OAuthAccessTokenException, "An access token is required to request this resource.")
     end
-    
+
     it "parses http response errors" do
       Mogli::Client.should_receive(:post).and_return(mock("httpresponse",:code=>500))
       client = Mogli::Client.new("1234")
       lambda do
         result = client.post("1/feed","Post",:message=>"message")
       end.should raise_error(Mogli::Client::HTTPException)
-      
     end
 
     it "creates objects of the returned type" do
@@ -152,13 +151,25 @@ describe Mogli::Client do
       result = client.post("1/feed","Post",:message=>"message")
       result.should == Mogli::Post.new(:id=>123434)
     end
-    
+
     it "creates object in a way that ignore invalid properties" do
       Mogli::Client.stub!(:post).and_return({:id=>123434,:completely_invalid_property=>1})
       client = Mogli::Client.new("1234")
       lambda do
         result = client.post("1/feed","Post",:message=>"message")
       end.should_not raise_error
+    end
+
+    it "parses an authentication failure due to invalid session or password change" do
+      err_type="OAuthException"
+      err_msg ="Error validating access token: Session does not match current stored session. This may be because the user changed the password since the time the session was created or Facebook has changed the session for security reasons."
+      response={"error"=>{"type"=>err_type,"message"=>err_msg}}
+      mock_response = mock("response",:parsed_response=>response,:code=>400,:kind_of? => true,:keys => ["error"],:[] => response["error"])
+      Mogli::Client.should_receive(:post).and_return(mock_response)
+      client = Mogli::Client.new("1234")
+      lambda do
+        result = client.post("1/feed","Post",:message=>"message")
+      end.should raise_error(Mogli::Client::SessionInvalidatedDueToPasswordChange, err_msg)
     end
 
     it "raises specific exception if Facebook-imposed posting limit exceeded for feed" do
@@ -251,7 +262,6 @@ describe Mogli::Client do
       client.map_to_class(false,Mogli::User).should be_false
     end
     
-
     it "returns the array if no class is specified and there is only a data parameter" do
       client.map_data({"data"=>[user_data,user_data]}).should be_kind_of(Array)
     end


### PR DESCRIPTION
When a session is invalidated (perhaps because the user changed their password) and we try to post to a user's feed, we get back an http response object with a 400 error code.  This was causing a general `HTTPException` to be raised; this should be the more specific `SessionInvalidatedDueToPasswordChange` exception.

In addition, updated status and photo properties for comments and likes.
