### PR TITLE
Issue #99 fix: deleted the overridding method get_and_map in AppClient

### DIFF
--- a/lib/mogli/app_client.rb
+++ b/lib/mogli/app_client.rb
@@ -32,9 +32,5 @@ module Mogli
     def post(path, klass, query)
       super("#{application_id}/#{path}", klass, query)
     end
-    
-    def get_and_map(path, klass, query)
-      super("#{application_id}/#{path}", klass, query)
-    end
   end
 end


### PR DESCRIPTION
Just deleted the get_and_map method which causes an OAuthException when using create_and_authenticate_as_application for an AppRequest. Travis needs to implement it differently for his TestUser class.
