### PR TITLE
Bump version to match current gem release

### DIFF
--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'mogli'
-  s.version = '0.0.36'
+  s.version = '0.0.37'
   s.summary = 'Open Graph Library for Ruby'
   s.description = 'Simple library for accessing the Facebook Open Graph API'
   s.files = Dir['lib/**/*.rb']


### PR DESCRIPTION
Current gem release is 0.0.37 but noticed that the gemspec still says 0.0.36.  Missed commit perhaps?
