### PR TITLE
Mogli client is more resilient to Facebook's JSON

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -161,10 +161,13 @@ module Mogli
       return nil if hash_or_array == false
       return hash_or_array if hash_or_array.nil? or hash_or_array.kind_of?(Array)
       return extract_fetching_array(hash_or_array,klass) if is_fetching_array?(hash_or_array)
+      # Facebook doesn't return numbers or booleans in an object or list
+      # container; this will catch the number, "true" and "false" response case
       return hash_or_array
     end
 
     def is_fetching_array?(hash)
+      return false unless hash.respond_to? :has_key
       hash.has_key?("data") and hash["data"].instance_of?(Array)
     end
 


### PR DESCRIPTION
Facebook APIs return numbers, "true" and "false" as valid JSON, even though the
JSON RFC defines JSON objects as starting with "[" or "{". As such, when the
client is looking at parsed JSON returned from a Facebook API call, it will
crash on numbers and booleans because they don't respond to the :has_keys?
method.
