### PR TITLE
Allow different versions of MultiJson

### DIFF
--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -12,7 +12,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'hashie', '>= 1.1.0'
   s.add_dependency 'httmultiparty', '>= 0.3.6'
   s.add_dependency 'httparty', '>= 0.4.3'
-  s.add_dependency 'multi_json', '~> 1.0.3'
+  s.add_dependency 'multi_json', '>= 1.0.3', '< 1.4'
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
I've switched from the ~> operator to an explicit upper and lower boundary. The upper boundary is partly arbitrary, but should be lower than 2.0, because in 2.0 breaking changes are going to be made.

The existing lower bound is kept, because nothing changed in how the gem is used, and to allow people to keep their existing working configuration.

This doesn't solve issue #115
