### PR TITLE
Fix for incorrect handling of requesting fields on an association. Currently (as of 5/22/2012) erroring out on Facebook.

### DIFF
--- a/lib/mogli/model.rb
+++ b/lib/mogli/model.rb
@@ -116,7 +116,7 @@ module Mogli
 
     def self.has_association(name,klass)
       define_method name do |*fields|
-        body_args = fields.empty? ? {} : {:fields => fields}
+        body_args = fields.empty? ? {} : {:fields => fields.join(',')}
         if (ret=instance_variable_get("@#{name}")).nil?
           ret = client.get_and_map("#{id}/#{name}",klass, body_args)
           instance_variable_set("@#{name}",ret)

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -34,7 +34,7 @@ describe Mogli::User do
 
     it "finds a user's friends with optional fields" do
       mock_client.should_receive(:get_and_map).with(
-        "1/friends", "User", {:fields => [:birthday, :gender]}).and_return(
+        "1/friends", "User", {:fields => 'birthday,gender'}).and_return(
         [Mogli::User.new(:id=>2, :birthday=>'09/15', :gender => 'male')])
       friends = user_1.friends(:birthday, :gender)
       friends.size.should == 1


### PR DESCRIPTION
If we request specific fields on an association, e.g.,
user.friends(:birthday, :first_name, :last_name)
the fields need to be translated into a single comma-separated parameter
for Facebook to respect it. Similar fix to c7b7fd8e
