### PR TITLE
Fixes multi_json dependency (not liberal enough)

### DIFF
--- a/mogli.gemspec
+++ b/mogli.gemspec
@@ -12,7 +12,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'hashie', '>= 1.1.0'
   s.add_dependency 'httmultiparty', '>= 0.3.6'
   s.add_dependency 'httparty', '>= 0.4.3'
-  s.add_dependency 'multi_json', '>= 1.0.3', '< 1.4'
+  s.add_dependency 'multi_json', '~> 1.0'
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
as per semantic version 2.0.0 ( http://semver.org/ )
see versioning section of multi_json: http://rubydoc.info/gems/multi_json/1.5.0/frames
- I am also concerned of the >= dependencies, but no issues as of yet
