### PR TITLE
When we do a #fetch on Mogli::User, we should get association relations ...

### DIFF
--- a/lib/mogli/model.rb
+++ b/lib/mogli/model.rb
@@ -109,6 +109,7 @@ module Mogli
       end
 
       add_creation_method(method_name,klass)
+      (@populating_accessors ||= []) << method_name
     end
 
     def self.hash_populating_accessor_with_default_field(method_name,default_field,*klass)
@@ -121,6 +122,7 @@ module Mogli
       end
 
       add_creation_method(method_name,klass)
+      (@populating_accessors ||= []) << method_name
     end
 
     def self.add_creation_method(name,klass)
@@ -146,6 +148,7 @@ module Mogli
       end
 
       add_creation_method(name,klass)
+      (@associations ||= []) << name
     end
 
     def fetch()
@@ -161,6 +164,12 @@ module Mogli
     
     def merge!(other)
       @_values.merge!(other.instance_variable_get("@_values"))
+      # We need to copy not only root values, but, for example, user.location
+      ( (self.class.instance_variable_get("@populating_accessors") || []) +
+        (self.class.instance_variable_get("@associations") || [])).each do |var_name|
+
+        instance_variable_set("@#{var_name}", other.instance_variable_get("@#{var_name}"))
+      end
     end
     
     def self.recognize?(data)


### PR DESCRIPTION
...(i.e., location)

If you do:

```
u1 = Mogli::User.find(fb_uid, mogli_client)
u1.location # Gets filled
-> bla bla
```

But if you do:

```
u2 = Mogli::User.new({id: fb_uid}, mogli_client)
u2.fetch.location
-> nil
```

This patch fixes this behaviour
