### PR TITLE
Mogli::Authenticator swallows the cause of API errors

### DIFF
--- a/lib/mogli/authenticator.rb
+++ b/lib/mogli/authenticator.rb
@@ -62,7 +62,7 @@ module Mogli
     end
 
     def raise_exception_if_required(response)
-      raise Mogli::Client::HTTPException if response.code != 200
+      raise Mogli::Client::HTTPException, response.body if response.code != 200
     end
 
   end


### PR DESCRIPTION
Just a quick hack here to stick the response body in the exception so you can at least see what failed.  
