### PR TITLE
Explicit catchall Accept and Content-Type headers.

### DIFF
--- a/lib/mogli/client.rb
+++ b/lib/mogli/client.rb
@@ -11,6 +11,8 @@ module Mogli
     include Mogli::Client::Event
     include Mogli::Client::User
 
+    headers 'Accept' => "*/*", 'Content-Type' => "*/*"
+
     class ClientException < StandardError; end
     class UnrecognizeableClassError < ClientException; end
     class QueryParseException < ClientException; end


### PR DESCRIPTION
Addresses https://github.com/mmangino/mogli/issues/144.

Without an `Accept` header field, Facebook returns JSON responses with
content-type `text/javascript`. As of HTTParty 0.12.0, content types of
`text/javascript` are parsed as plain text instead of JSON,
causing parsing of their response bodies to break.
